### PR TITLE
Allow yielding inside of __len metamethods

### DIFF
--- a/src/lauxlib.c
+++ b/src/lauxlib.c
@@ -369,7 +369,7 @@ LUALIB_API int luaL_getn (lua_State *L, int t) {
 }
 
 LUALIB_API int luaL_igetn (lua_State *L, int t, int ictx) {
-  if (ictx && lua_icontext(L) == ictx) goto resume;
+  if (ictx != 0 && lua_icontext(L) == ictx) goto resume;
   int n;
   t = abs_index(L, t);
   lua_pushliteral(L, "n");  /* try t.n */

--- a/src/lauxlib.c
+++ b/src/lauxlib.c
@@ -365,6 +365,11 @@ LUALIB_API void luaL_setn (lua_State *L, int t, int n) {
 
 
 LUALIB_API int luaL_getn (lua_State *L, int t) {
+  return luaL_igetn(L, t, 0);
+}
+
+LUALIB_API int luaL_igetn (lua_State *L, int t, int ictx) {
+  if (ictx && lua_icontext(L) == ictx) goto resume;
   int n;
   t = abs_index(L, t);
   lua_pushliteral(L, "n");  /* try t.n */
@@ -378,7 +383,8 @@ LUALIB_API int luaL_getn (lua_State *L, int t) {
     lua_getfield(L, -1, "__len");
     if (lua_isfunction(L, -1)) {
       lua_pushvalue(L, t);
-      lua_call(L, 1, 1);
+      lua_icall(L, 1, 1, ictx);
+  resume:
       if (lua_isnumber(L, -1)) {
         n = lua_tointeger(L, -1);
         lua_pop(L, 2);

--- a/src/lauxlib.h
+++ b/src/lauxlib.h
@@ -17,9 +17,11 @@
 
 #if defined(LUA_COMPAT_GETN)
 LUALIB_API int (luaL_getn) (lua_State *L, int t);
+LUALIB_API int (luaL_igetn) (lua_State *L, int t, int ictx);
 LUALIB_API void (luaL_setn) (lua_State *L, int t, int n);
 #else
 #define luaL_getn(L,i)          ((int)lua_objlen(L, i))
+#define luaL_igetn(L,i,c)       ((int)lua_objlen(L, i))
 #define luaL_setn(L,i,j)        ((void)0)  /* no op! */
 #endif
 

--- a/src/lbaselib.c
+++ b/src/lbaselib.c
@@ -356,7 +356,9 @@ static int luaB_unpack (lua_State *L) {
   int i, e, n;
   luaL_checktype(L, 1, LUA_TTABLE);
   i = luaL_optint(L, 2, 1);
-  e = luaL_opt(L, luaL_checkint, 3, luaL_getn(L, 1));
+  /* prevent igetn from pushing things over the optional arguments */
+  if (lua_icontext(L) == 0) lua_settop(L, 3);
+  e = luaL_opt(L, luaL_checkint, 3, luaL_igetn(L, 1, 1));
   if (i > e) return 0;  /* empty range */
   n = e - i + 1;  /* number of elements */
   if (n <= 0 || !lua_checkstack(L, n))  /* n <= 0 means arith. overflow */

--- a/src/ltablib.c
+++ b/src/ltablib.c
@@ -17,6 +17,7 @@
 
 
 #define aux_getn(L,n)	(luaL_checktype(L, n, LUA_TTABLE), luaL_getn(L, n))
+#define aux_igetn(L,n,c)	(luaL_checktype(L, n, LUA_TTABLE), luaL_igetn(L, n, c))
 
 
 static int foreachi (lua_State *L) {

--- a/src/ltablib.c
+++ b/src/ltablib.c
@@ -23,14 +23,14 @@
 static int foreachi (lua_State *L) {
   int n;
   int i = lua_icontext(L);
-  if (i) {
+  if (i > 0) {
     n = lua_tointeger(L, 3);  /* get cached n */
     goto resume;
   }
-  n = aux_getn(L, 1);
+  n = aux_igetn(L, 1, -1);
    luaL_checktype(L, 2, LUA_TFUNCTION);
   lua_settop(L, 2);
-  lua_pushinteger(L, n);  /* cache n because aux_getn may be expensive */
+  lua_pushinteger(L, n);  /* cache n because aux_igetn may be expensive */
    for (i=1; i <= n; i++) {
      lua_pushvalue(L, 2);  /* function */
      lua_pushinteger(L, i);  /* 1st argument */
@@ -80,7 +80,7 @@ static int maxn (lua_State *L) {
 
 
 static int getn (lua_State *L) {
-  lua_pushinteger(L, aux_getn(L, 1));
+  lua_pushinteger(L, aux_igetn(L, 1, 1));
   return 1;
 }
 
@@ -98,7 +98,7 @@ static int setn (lua_State *L) {
 
 
 static int tinsert (lua_State *L) {
-  int e = aux_getn(L, 1) + 1;  /* first empty element */
+  int e = aux_igetn(L, 1, 1) + 1;  /* first empty element */
   int pos;  /* where to insert new element */
   switch (lua_gettop(L)) {
     case 2: {  /* called with only 2 arguments */
@@ -126,7 +126,7 @@ static int tinsert (lua_State *L) {
 
 
 static int tremove (lua_State *L) {
-  int e = aux_getn(L, 1);
+  int e = aux_igetn(L, 1, 1);
   int pos = luaL_optint(L, 2, e);
   if (!(1 <= pos && pos <= e))  /* position is outside bounds? */
    return 0;  /* nothing to remove */
@@ -158,7 +158,8 @@ static int tconcat (lua_State *L) {
   const char *sep = luaL_optlstring(L, 2, "", &lsep);
   luaL_checktype(L, 1, LUA_TTABLE);
   i = luaL_optint(L, 3, 1);
-  last = luaL_opt(L, luaL_checkint, 4, luaL_getn(L, 1));
+  if (!lua_icontext(L)) lua_settop(L, 4);
+  last = luaL_opt(L, luaL_checkint, 4, luaL_igetn(L, 1, 1));
   luaL_buffinit(L, &b);
   for (; i < last; i++) {
     addfield(L, &b, i);
@@ -311,11 +312,11 @@ static int sort (lua_State *L) {
   int n;
   void * ud = NULL;
   lua_Alloc alloc = lua_getallocf(L, &ud);
-  if (lua_vcontext(L)) {
+  if (lua_icontext(L) > 0) {
     s = (struct table_sort_state*)lua_vcontext(L);
     goto resume;
   }
-  n = aux_getn(L, 1);
+  n = aux_igetn(L, 1, -1);
   luaL_checkstack(L, 40, "");  /* assume array is smaller than 2^40 */
   if (!lua_isnoneornil(L, 2))  /* is there a 2nd argument? */
     luaL_checktype(L, 2, LUA_TFUNCTION);
@@ -351,7 +352,8 @@ static int tunpack (lua_State *L) {
   int i, e, n;
   luaL_checktype(L, 1, LUA_TTABLE);
   i = luaL_optint(L, 2, 1);
-  e = luaL_opt(L, luaL_checkint, 3, luaL_getn(L, 1));
+  if (lua_icontext(L) == 0) lua_settop(L, 3);
+  e = luaL_opt(L, luaL_checkint, 3, luaL_igetn(L, 1, 1));
   if (i > e) return 0;  /* empty range */
   n = e - i + 1;  /* number of elements */
   if (n <= 0 || !lua_checkstack(L, n))  /* n <= 0 means arith. overflow */


### PR DESCRIPTION
This is done by adding a new function to the API which supports resumption, and migrating all functions which use `luaL_getn` to `luaL_igetn`.

Tested:
- unpack
- table.foreachi
- table.getn

Untested:
- table.insert
- table.remove
- table.sort
- table.unpack

Not tested for memory leaks.