### PR TITLE
Fix string comparison errors

### DIFF
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -276,7 +276,7 @@ int luaV_lessthan (lua_State *L, const TValue *l, const TValue *r) {
     resolvesubstr(L, l);
     resolvesubstr(L, r);
   }
-  if (ttype(l) != ttype(r))
+  if (ttypenv(l) != ttypenv(r))
     luaG_ordererror(L, l, r);
   else if (ttisnumber(l))
     return luai_numlt(L, nvalue(l), nvalue(r));
@@ -298,7 +298,7 @@ int luaV_lessequal (lua_State *L, const TValue *l, const TValue *r) {
     resolvesubstr(L, l);
     resolvesubstr(L, r);
   }
-  if (ttype(l) != ttype(r))
+  if (ttypenv(l) != ttypenv(r))
     luaG_ordererror(L, l, r);
   else if (ttisnumber(l))
     return luai_numle(L, nvalue(l), nvalue(r));


### PR DESCRIPTION
Fixes two errors:
1. `"a" < ("a"):rep(41)` throwing an error when trying to compare a short string with a long string.
2. `("\xff"):rep(20):sub(1, 10) < ("\xff"):rep(20):sub(1, 10)` sometimes returning true.

We also simplify the string comparison functions and merge both of them into a single function, which handles all string/substring combinations without allocation, except when resolving ropes. Previous comparisons used `strcoll()` plus a hack to make them carry on past null bytes. Since we now use `strcmp()` we don't need that and can replace the whole thing with `memcmp()` instead.